### PR TITLE
refactor(hapi/basicAuth): Update hapi deps

### DIFF
--- a/nodejs/hapi/basicAuth/package.json
+++ b/nodejs/hapi/basicAuth/package.json
@@ -7,8 +7,8 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "hapi": "^18.1.0",
-    "hapi-auth-basic": "^5.0.0",
+    "@hapi/hapi": "^20.0.0",
+    "@hapi/basic": "^6.0.0",
     "idb-pconnector": "^1.0.4"
   },
   "devDependencies": {

--- a/nodejs/hapi/basicAuth/server.js
+++ b/nodejs/hapi/basicAuth/server.js
@@ -2,8 +2,8 @@ const {
   Connection, IN, CHAR,
 } = require('idb-pconnector');
 
-const Hapi = require('hapi');
-const basicAuth = require('hapi-auth-basic');
+const Hapi = require('@hapi/hapi');
+const basicAuth = require('@hapi/basic');
 
 const port = process.env.PORT || 4000;
 const verbose = process.env.DEBUG;


### PR DESCRIPTION
Security Advisory GHSA-7hx8-2rxv-66xv was raised.

The recommendation is to update your dependencies to use @hapi/hapi.

Also hapi basic auth has moved to @hapi/basic