### PR TITLE
refactor(hapi/cookieAuth): Update hapi deps

### DIFF
--- a/nodejs/hapi/cookieAuth/package.json
+++ b/nodejs/hapi/cookieAuth/package.json
@@ -6,14 +6,14 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "hapi": "^18.1.0",
-    "hapi-auth-basic": "^5.0.0",
-    "hapi-auth-cookie": "^10.0.0",
+    "@hapi/hapi": "^20.0.0",
+    "@hapi/basic": "^6.0.0",
+    "@hapi/cookie": "^11.0.1",
     "hoek": "^6.1.3",
     "inert": "^5.1.2",
     "pug": "^2.0.3",
     "vision": "^5.4.4",
-    "idb-pconnector": "^1.0.4", 
+    "idb-pconnector": "^1.0.4",
     "uuid": "3.3.2"
   }
 }

--- a/nodejs/hapi/cookieAuth/server.js
+++ b/nodejs/hapi/cookieAuth/server.js
@@ -1,5 +1,5 @@
-const Hapi = require('hapi');
-const cookie = require('hapi-auth-cookie');
+const Hapi = require('@hapi/hapi');
+const cookie = require('@hapi/cookie');
 const pug = require('pug'); // Template engine
 const vision = require('vision'); // Templates rendering plugin support for hapi.js.
 const inert = require('inert'); // Static file and directory handlers plugin for hapi.js.


### PR DESCRIPTION
Security Advisory GHSA-7hx8-2rxv-66xv was raised.

The recommendation is to update your dependencies to use @hapi/hapi.

Also hapi cookie auth has moved to @hapi/cookie